### PR TITLE
Synthetic data: adding positive data option

### DIFF
--- a/datasets/simulated.py
+++ b/datasets/simulated.py
@@ -1,4 +1,5 @@
 from benchopt import BaseDataset, safe_import_context
+from benchopt.datasets.simulated import make_correlated_data
 
 
 with safe_import_context() as import_ctx:
@@ -16,21 +17,22 @@ class Dataset(BaseDataset):
         'pos_data': [True,False],
     }
 
-    def __init__(self, n_samples=10, n_features=50, pos_data=False, random_state=27):
+    def __init__(self, n_samples=10, n_features=50, pos_data=False, rho=0,
+                 random_state=27):
         # Store the parameters of the dataset
         self.n_samples = n_samples
         self.n_features = n_features
         self.pos_data = pos_data
         self.random_state = random_state
+        self.rho = rho
 
     def get_data(self):
 
         rng = np.random.RandomState(self.random_state)
-        X = rng.randn(self.n_samples, self.n_features)
-        y = rng.randn(self.n_samples)
-        if self.pos_data:
-            X = np.abs(X)
-            y = np.abs(y)
+
+        X, y, _ = make_correlated_data(self.n_samples, self.n_features,
+                                       rho=self.rho, random_state=rng,
+                                       pos_data = self.pos_data)
 
         data = dict(X=X, y=y)
 

--- a/datasets/simulated.py
+++ b/datasets/simulated.py
@@ -11,12 +11,16 @@ class Dataset(BaseDataset):
 
     # List of parameters to generate the datasets. The benchmark will consider
     # the cross product for each key in the dictionary.
-    parameters = {'n_samples, n_features': [(100, 5000), (100, 10000)]}
+    parameters = {
+        'n_samples, n_features': [(100, 5000), (100, 10000)],
+        'positive_data': [True,False],
+    }
 
-    def __init__(self, n_samples=10, n_features=50, random_state=27):
+    def __init__(self, n_samples=10, n_features=50, positive_data=False, random_state=27):
         # Store the parameters of the dataset
         self.n_samples = n_samples
         self.n_features = n_features
+        self.positive_data = positive_data
         self.random_state = random_state
 
     def get_data(self):
@@ -24,6 +28,9 @@ class Dataset(BaseDataset):
         rng = np.random.RandomState(self.random_state)
         X = rng.randn(self.n_samples, self.n_features)
         y = rng.randn(self.n_samples)
+        if self.positive_data:
+            X = np.abs(X)
+            y = np.abs(y)
 
         data = dict(X=X, y=y)
 

--- a/datasets/simulated.py
+++ b/datasets/simulated.py
@@ -4,6 +4,7 @@ from benchopt.datasets.simulated import make_correlated_data
 
 with safe_import_context() as import_ctx:
     import numpy as np
+    from numpy.linalg import norm
 
 
 class Dataset(BaseDataset):
@@ -14,25 +15,36 @@ class Dataset(BaseDataset):
     # the cross product for each key in the dictionary.
     parameters = {
         'n_samples, n_features': [(100, 5000), (100, 10000)],
-        'pos_data': [True, False],
+        'positive': [True, False],
     }
 
-    def __init__(self, n_samples=10, n_features=50, pos_data=False, rho=0,
-                 random_state=27):
+    def __init__(self, n_samples=10, n_features=50, positive=False, rho=0,
+                 snr=3, random_state=27):
         # Store the parameters of the dataset
         self.n_samples = n_samples
         self.n_features = n_features
-        self.pos_data = pos_data
+        self.positive = positive
         self.random_state = random_state
         self.rho = rho
+        self.snr = snr
 
     def get_data(self):
 
         rng = np.random.RandomState(self.random_state)
 
-        X, y, _ = make_correlated_data(self.n_samples, self.n_features,
-                                       rho=self.rho, random_state=rng,
-                                       pos_data=self.pos_data)
+        X, y, w_true = make_correlated_data(self.n_samples, self.n_features,
+                                            rho=self.rho, random_state=rng)
+
+        if self.positive:
+            X = np.abs(X)
+            w_true = np.abs(w_true)
+            # Regenerate y
+            y = X @ w_true
+            noise = rng.randn(self.n_samples)
+            if self.snr not in [0, np.inf]:
+                y += noise / norm(noise) * norm(y) / self.snr
+            elif self.snr == 0:
+                y = noise
 
         data = dict(X=X, y=y)
 

--- a/datasets/simulated.py
+++ b/datasets/simulated.py
@@ -13,14 +13,14 @@ class Dataset(BaseDataset):
     # the cross product for each key in the dictionary.
     parameters = {
         'n_samples, n_features': [(100, 5000), (100, 10000)],
-        'positive_data': [True,False],
+        'pos_data': [True,False],
     }
 
-    def __init__(self, n_samples=10, n_features=50, positive_data=False, random_state=27):
+    def __init__(self, n_samples=10, n_features=50, pos_data=False, random_state=27):
         # Store the parameters of the dataset
         self.n_samples = n_samples
         self.n_features = n_features
-        self.positive_data = positive_data
+        self.pos_data = pos_data
         self.random_state = random_state
 
     def get_data(self):
@@ -28,7 +28,7 @@ class Dataset(BaseDataset):
         rng = np.random.RandomState(self.random_state)
         X = rng.randn(self.n_samples, self.n_features)
         y = rng.randn(self.n_samples)
-        if self.positive_data:
+        if self.pos_data:
             X = np.abs(X)
             y = np.abs(y)
 

--- a/datasets/simulated.py
+++ b/datasets/simulated.py
@@ -14,7 +14,7 @@ class Dataset(BaseDataset):
     # the cross product for each key in the dictionary.
     parameters = {
         'n_samples, n_features': [(100, 5000), (100, 10000)],
-        'pos_data': [True,False],
+        'pos_data': [True, False],
     }
 
     def __init__(self, n_samples=10, n_features=50, pos_data=False, rho=0,
@@ -32,7 +32,7 @@ class Dataset(BaseDataset):
 
         X, y, _ = make_correlated_data(self.n_samples, self.n_features,
                                        rho=self.rho, random_state=rng,
-                                       pos_data = self.pos_data)
+                                       pos_data=self.pos_data)
 
         data = dict(X=X, y=y)
 


### PR DESCRIPTION
Adding a synthetic simulation scenario with non-negative data (X,y), controlled by flag `pos_data`.
I believe this new simulation scenario to be essential as it is commonly considered in practice.
Also, it can significantly affect the benchmark results. For instance, the fastest solver can be `cd` or `scipy` (active-set) depending on whether (X,y) is positive or not (see below).

`benchopt run -e . -d Simulated[n_features=100,n_samples=1000] -s cd -s scipy -r 1`

![Screenshot from 2022-07-08 16-10-03](https://user-images.githubusercontent.com/774058/178008820-ebaa7440-c469-4cd4-850a-35d2bc406659.png)
![Screenshot from 2022-07-08 16-10-16](https://user-images.githubusercontent.com/774058/178008812-b489248c-d550-4787-b77a-5d8696d80c07.png)
