### PR TITLE
FIX - running methods of ``skglm`` and ``scikit-learn`` solvers

### DIFF
--- a/solvers/skglm.py
+++ b/solvers/skglm.py
@@ -35,7 +35,7 @@ class Solver(BaseSolver):
         ).fit(X, y)
 
     def run(self, n_iter):
-        self.clf.max_iter = n_iter
+        self.clf.solver.max_iter = n_iter
         self.clf.fit(self.X, self.y)
 
     def get_result(self):

--- a/solvers/sklearn.py
+++ b/solvers/sklearn.py
@@ -24,8 +24,15 @@ class Solver(BaseSolver):
         warnings.filterwarnings('ignore', category=ConvergenceWarning)
 
     def run(self, n_iter):
+        if n_iter == 0:
+            n_features = self.X.shape[1] + self.fit_intercept
+            self.coef = np.zeros(n_features)
+            return
+
         self.clf.max_iter = n_iter
         self.clf.fit(self.X, self.y)
 
+        self.coef = self.clf.coef_.flatten()
+
     def get_result(self):
-        return self.clf.coef_.flatten()
+        return self.coef


### PR DESCRIPTION
This addresses two issues:
- [x] skip ``n_iter=0`` for scikit-learn solver
Passing in ``max_iter=0`` to Lasso raises an exception
- [x] update ``max_iter`` of skglm solver
``max_iter`` wasn't updated correctly which lead to a plateau objective value