### PR TITLE
FIX leukemia

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,11 +8,14 @@ reproducible the comparisons of optimization algorithms.
 The Non-Negative Least Square consists in solving the following program:
 
 
-$$\\min_{w \\geq 0} \\frac{1}{2} \\lVert y - Xw \\rVert^2_2$$
+$${\\min}_{w \\geq 0} \\frac{1}{2} \\lVert y - Xw \\rVert^2_2$$
 
 where $n$ (or ``n_samples``) stands for the number of samples, $p$ (or ``n_features``) stands for the number of features and
 
 $$y \\in \\mathbb{R}^n, X = [x_1^\\top, \\dots, x_n^\\top]^\\top \\in \\mathbb{R}^{n \\times p}$$
+
+
+In case a $w$ with negative entries is passed, those entries are set to 0 to evaluate the objective function at a feasible point.
 
 Install
 --------

--- a/datasets/leukemia.py
+++ b/datasets/leukemia.py
@@ -19,9 +19,9 @@ class Dataset(BaseDataset):
         # Unlike libsvm[leukemia], this dataset corresponds to the whole
         # leukemia  data with train + test data (72 samples) and not just
         # the training set.
-        X, y = fetch_openml("leukemia", return_X_y=True)
-        X = X.to_numpy()
-        y = LabelBinarizer().fit_transform(y)[:, 0].astype(X.dtype)
+        X, y = fetch_openml("leukemia", return_X_y=True, parser='auto')
+        X = X.to_numpy(dtype=float)
+        y = LabelBinarizer().fit_transform(y)[:, 0].astype(float)
         data = dict(X=X, y=y)
 
         return data

--- a/objective.py
+++ b/objective.py
@@ -23,11 +23,10 @@ class Objective(BaseObjective):
         return dict(beta=np.zeros(n_features))
 
     def evaluate_result(self, beta):
-        if (beta >= 0).all():
-            diff = self.y - self.X.dot(beta)
-            return .5 * diff.dot(diff)
-        else:
-            return np.inf
+        # project onto feasible set
+        beta = np.maximum(0, beta)
+        diff = self.y - self.X.dot(beta)
+        return .5 * diff.dot(diff)
 
     def get_objective(self):
         return dict(X=self.X, y=self.y, fit_intercept=self.fit_intercept)


### PR DESCRIPTION
scipy returns negative coefficients, hence our current implem gives it an objective value of `np.inf` and it is marked as "diverged". Clipping negative coefficients to 0 seems less extreme IMO

CD's numba doesn't like dot product when the datatype is int, hence I return leukemia's data as float, not int.